### PR TITLE
Implement topic for updating device info entries

### DIFF
--- a/custom_components/senziio/__init__.py
+++ b/custom_components/senziio/__init__.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 import logging
-
-from senziio import Senziio, SenziioMQTT
+from collections.abc import Callable
 
 from homeassistant.components import mqtt
 from homeassistant.components.mqtt import async_publish, async_subscribe
@@ -15,10 +13,15 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
 from .entity import DOMAIN
+from .senziio import Senziio, SenziioMQTT
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BINARY_SENSOR]
+PLATFORMS: list[Platform] = [
+    Platform.SENSOR,
+    Platform.BINARY_SENSOR,
+    Platform.UPDATE,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/senziio/config_flow.py
+++ b/custom_components/senziio/config_flow.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from senziio import Senziio
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -16,6 +15,7 @@ from homeassistant.exceptions import HomeAssistantError
 
 from . import MQTTError, SenziioHAMQTT
 from .entity import DOMAIN, MANUFACTURER
+from .senziio import Senziio
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/senziio/entity.py
+++ b/custom_components/senziio/entity.py
@@ -18,13 +18,26 @@ class SenziioEntity(Entity):
 
     @property
     def device_info(self) -> DeviceInfo:
-        """Return device info."""
+        dev_reg = dr.async_get(self.hass)
+        dev_entry = dev_reg.async_get_device(
+            identifiers={(DOMAIN, self.entry.data["serial-number"])}
+        )
+        if dev_entry:
+            sw_version = dev_entry.sw_version
+            serial_number = dev_entry.serial_number
+            connections = dev_entry.connections or set()
+        else:
+            sw_version = self.entry.data.get("fw-version")
+            serial_number = self.entry.data.get("serial-number")
+            mac = self.entry.data.get("mac-address")
+            connections = {(dr.CONNECTION_NETWORK_MAC, mac)} if mac else set()
+
         return DeviceInfo(
             identifiers={(DOMAIN, self.entry.data["serial-number"])},
             name=self.entry.title,
             manufacturer=MANUFACTURER,
             model=self.entry.data["model"],
-            sw_version=self.entry.data["fw-version"],
-            serial_number=self.entry.data["serial-number"],
-            connections={(dr.CONNECTION_NETWORK_MAC, self.entry.data["mac-address"])},
+            sw_version=sw_version,
+            serial_number=serial_number,
+            connections=connections,
         )

--- a/custom_components/senziio/manifest.json
+++ b/custom_components/senziio/manifest.json
@@ -3,13 +3,13 @@
   "name": "Senziio",
   "codeowners": ["@senziio-admin"],
   "config_flow": true,
+  "supported_platforms": ["sensor", "binary_sensor", "update"],
   "dependencies": ["mqtt"],
   "documentation": "https://github.com/senziio-admin/hacs-senziio-integration",
   "homekit": {},
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/senziio-admin/hacs-senziio-integration/issues",
-  "requirements": ["senziio==0.0.1"],
-  "version": "v1.1.1",
+  "version": "v1.1.2",
   "zeroconf": [
     {
         "name": "senziio*",

--- a/custom_components/senziio/senziio.py
+++ b/custom_components/senziio/senziio.py
@@ -1,0 +1,104 @@
+"""API for interacting with Senziio Devices."""
+
+import asyncio
+import json
+import logging
+from abc import ABC, abstractmethod
+
+logger = logging.getLogger(__name__)
+
+
+class SenziioMQTT(ABC):
+    """Senziio MQTT communication interface."""
+
+    @abstractmethod
+    async def publish(self, topic, payload):
+        """Publish to topic with a payload."""
+
+    @abstractmethod
+    async def subscribe(self, topic, callback):
+        """Subscribe to topic with a callback."""
+
+
+class Senziio:
+    """Senziio device communications."""
+
+    GET_INFO_TIMEOUT = 10
+
+    def __init__(self, device_id: str, device_model: str, mqtt: SenziioMQTT) -> None:
+        """Initialize instance."""
+        self.device_id = device_id
+        self.model_key = "-".join(device_model.lower().split())
+        self.mqtt = mqtt
+        self.topics = {
+            "info_req": f"cmd/{self.model_key}/{device_id}/device-info/req",
+            "info_res": f"cmd/{self.model_key}/{device_id}/device-info/res",
+            "data": f"dt/{self.model_key}/{device_id}",
+            "device_info": f"dt/{self.model_key}/{device_id}/device-info",
+        }
+
+    @property
+    def id(self):
+        """Return ID of device."""
+        return self.device_id
+
+    def entity_topic(self, entity: str) -> str:
+        """Get topic for listening to entity data updates."""
+        return f"{self.topics['data']}/{entity}"
+
+    async def get_info(self):
+        """Get device info."""
+        device_info = {}
+        response = asyncio.Event()
+
+        async def handle_response(message):
+            """Handle device info response."""
+            nonlocal device_info
+            try:
+                device_info = json.loads(message.payload)
+            except json.JSONDecodeError:
+                logger.error(
+                    "Could not parse device info payload: %s", message.payload
+                )
+            response.set()
+
+        unsubscribe_callback = await self.mqtt.subscribe(
+            self.topics["info_res"],
+            handle_response,
+        )
+
+        await self.mqtt.publish(
+            self.topics["info_req"],
+            "Device info request",
+        )
+
+        try:
+            await asyncio.wait_for(response.wait(), self.GET_INFO_TIMEOUT)
+            return device_info
+        except TimeoutError:
+            return None
+        finally:
+            unsubscribe_callback()
+
+    async def listen_device_info_updates(self, callback) -> None:
+        """Listen device info updates topic.
+
+        Example payload:
+
+            {"firmware_version": "6.0.0", "serial_number": "theia_123456", "mac": "ABCD1234"}
+
+        """
+        async def _handler(message):
+            try:
+                data = json.loads(message.payload)
+            except json.JSONDecodeError:
+                logger.error("Bad device info payload: %s", message.payload)
+                return
+
+            await callback(
+                str(data.get("firmware_version")) or None,
+                str(data.get("serial_number")) or None,
+                str(data.get("mac")) or None,
+            )
+
+        await self.mqtt.subscribe(self.topics['device_info'], _handler)

--- a/custom_components/senziio/update.py
+++ b/custom_components/senziio/update.py
@@ -1,0 +1,194 @@
+"""Senziio firmware update entity."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.update import (
+    UpdateEntity,
+    UpdateEntityFeature,
+    UpdateDeviceClass,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.entity import EntityCategory
+
+from .entity import DOMAIN, MANUFACTURER
+from .senziio import Senziio
+
+logger = logging.getLogger(__name__)
+
+
+class SenziioUpdate(UpdateEntity):
+    """Update entity for Senziio devices."""
+
+    _attr_device_class = UpdateDeviceClass.FIRMWARE
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_supported_features = (
+        UpdateEntityFeature.INSTALL |
+        UpdateEntityFeature.PROGRESS
+    )
+
+    def __init__(self, device: Senziio, entry: ConfigEntry) -> None:
+        self._device = device
+        self._entry = entry
+        self._attr_unique_id = f"{device.id}_update"
+        self._identifiers = {(DOMAIN, device.id)}
+
+        self._installed: str | None = None
+        self._latest: str | None = None
+        self._progress: int | None = None
+        self._installed_saved: str | None = None
+
+        self._attr_device_info = {
+            "identifiers": self._identifiers,
+            "manufacturer": MANUFACTURER,
+        }
+
+    @property
+    def installed_version(self) -> str | None:
+        return self._installed
+
+    @property
+    def latest_version(self) -> str | None:
+        return self._latest
+
+    @property
+    def in_progress(self) -> bool | None:
+        return self._progress is not None
+
+    @property
+    def update_percentage(self) -> int | None:
+        """0-100 while flashing, None otherwise."""
+        return self._progress
+
+    @property
+    def progress(self) -> int | None:
+        return self._progress
+
+    async def async_install(self, version=None, backup=False, **kwargs):
+        """Triggered by the INSTALL button in the UI."""
+        self._progress = 0
+        self.async_write_ha_state()
+
+    async def _handle_firmware_update(
+        self,
+        current: str,
+        latest: str | None,
+        progress: int | None,
+    ) -> None:
+        """Handle firmware update flow.
+
+        TODO: topic not implemented, logic not defined.
+        """
+        changed = False
+
+        if current and current != self._installed:
+            self._installed = current
+            changed = True
+
+        if latest and latest != self._latest:
+            self._latest = latest
+            changed = True
+
+        if progress is not None:
+            pct = int(progress)
+            if pct != self._progress:
+                self._progress = pct
+                changed = True
+        else:
+            if self._progress is not None:
+                self._progress = None
+                changed = True
+
+        if changed:
+            self.async_write_ha_state()
+
+            # If no update is running AND the reported version differs from what
+            # we previously have stored, write it into device registry
+            if progress is None and current and current != self._installed_saved:
+                await self._save_firmware_version_to_registry(cur)
+                self._installed_saved = current
+
+    async def _handle_device_info_update(
+        self,
+        firmware_version: str | None,
+        serial_number: str | None,
+        mac: int | None,
+    ) -> None:
+        """Handle messages to update device info in registry."""
+        if firmware_version:
+            self._installed = firmware_version
+            self._latest = firmware_version
+            await self._save_firmware_version_to_registry(firmware_version)
+        if serial_number:
+            await self._save_serial_number_to_registry(serial_number)
+        if mac:
+            await self._save_mac_to_registry(mac)
+        self.async_write_ha_state()
+
+    async def _save_firmware_version_to_registry(self, firmware_version: str) -> None:
+        dev_reg = dr.async_get(self.hass)
+        dev_entry = dev_reg.async_get_device(self._identifiers)
+        if dev_entry and dev_entry.sw_version != firmware_version:
+            logger.debug(
+                "Updating Device Registry firmware version from %s to %s",
+                dev_entry.sw_version, firmware_version
+            )
+            dev_reg.async_update_device(dev_entry.id, sw_version=firmware_version)
+
+    async def _save_serial_number_to_registry(self, serial_number: str) -> None:
+        dev_reg = dr.async_get(self.hass)
+        dev_entry = dev_reg.async_get_device(self._identifiers)
+        if dev_entry and dev_entry.serial_number != serial_number:
+            logger.debug(
+                "Updating Device Registry serial number from %s to %s",
+                dev_entry.serial_number, serial_number
+            )
+            dev_reg.async_update_device(dev_entry.id, serial_number=serial_number)
+
+    async def _save_mac_to_registry(self, mac: str) -> None:
+        dev_reg = dr.async_get(self.hass)
+        dev_entry = dev_reg.async_get_device(self._identifiers)
+        if dev_entry is None:
+            return
+
+        conns = {c for c in dev_entry.connections
+                if c[0] != dr.CONNECTION_NETWORK_MAC}
+        conns.add((dr.CONNECTION_NETWORK_MAC, mac))
+
+        if conns == dev_entry.connections:
+            return
+
+        logger.debug(
+            "Updating Device Registry MAC from %s to %s",
+            next((c[1] for c in dev_entry.connections
+                if c[0] == dr.CONNECTION_NETWORK_MAC), "none"),
+            mac,
+        )
+
+        await dev_reg.async_update_device(
+            dev_entry.id,
+            new_connections=conns,
+        )
+
+        # also update mac in config entry
+        new_data = {**self._entry.data, "mac-address": mac}
+        self.hass.config_entries.async_update_entry(self._entry, data=new_data)
+
+    async def async_added_to_hass(self) -> None:
+        dev_reg = dr.async_get(self.hass)
+        dev_entry = dev_reg.async_get_device(self._identifiers)
+        if dev_entry and dev_entry.sw_version:
+            self._installed = dev_entry.sw_version
+            self._latest = dev_entry.sw_version
+            self._installed_saved = dev_entry.sw_version
+            self.async_write_ha_state()
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Create the entity and hook it to firmware-info messages."""
+    device: Senziio = hass.data["senziio"][entry.entry_id]
+    entity = SenziioUpdate(device, entry)
+    async_add_entities([entity])
+    await device.listen_device_info_updates(entity._handle_device_info_update)

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
     "name": "Senziio",
-    "homeassistant": "2024.4.0",
+    "homeassistant": "2024.6.0",
     "render_readme": true
 }


### PR DESCRIPTION
Fields that can be updated:

* Serial number
* Firmware version
* MAC address

Topic:
```
dt/<identified>/device-info
```

Payload:
```
{"firmware_version": "6.0.0", "serial_number": "theia_1234", "mac": "AB:CD:12:34"}
```

Also in this pull request the `senziio` PyPI dependency is removed and incorporated in the integration codebase to ease development.
